### PR TITLE
Fix upload

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -134,11 +134,11 @@ function onTorrent (torrent) {
 
   torrent.swarm.on('download', function () {
     var progress = (100 * torrent.downloaded / torrent.parsedTorrent.length).toFixed(1)
-    util.logReplace('Progress: ' + progress + '% -- download speed: ' + prettysize(torrent.swarm.downloadSpeed()) + '/s')
+    util.logReplace('Progress: ' + progress + '% -- Download speed: ' + prettysize(torrent.swarm.downloadSpeed()) + '/s')
   })
 
   torrent.swarm.on('upload', function () {
-    util.logReplace('upload speed:' + prettysize(torrent.swarm.uploadSpeed()) + '/s')
+    util.logReplace('Upload speed: ' + prettysize(client.uploadSpeed()) + '/s')
   })
 
   torrent.files.forEach(function (file) {


### PR DESCRIPTION
I made the first letter of download and upload speed capitals because I think it looks better and made it so there's a space between upload speed and its value. Changed torrent.swarm.uploadSpeed() back to client.uploadSpeed() so that it works. Let me know if there are any issues. There is also flickering when a file such as a video is still downloading and uploading to a peer at the same time, which may need fixing.