### PR TITLE
Prevent logReplace from being wrapped in <br>

### DIFF
--- a/client/util.js
+++ b/client/util.js
@@ -1,16 +1,11 @@
 var log = document.querySelector('.log')
 var logHeading = document.querySelector('#logHeading')
 
-exports.logAppend = function logAppend (item) {
+exports.logAppend = function logAppend (str) {
   logHeading.style.display = 'block'
-  if (typeof item === 'string') {
-    var p = document.createElement('p')
-    p.innerHTML = item
-    log.appendChild(p)
-  } else {
-    log.appendChild(item)
-    log.appendChild(document.createElement('br'))
-  }
+  var p = document.createElement('p')
+  p.innerHTML = str
+  log.appendChild(p)
 }
 
 // replace the last P in the log


### PR DESCRIPTION
This is an attempt to make the download and upload speeds appear properly. At the moment they are not replacing the last P and are being wrapped in br tags, so that they do not appear. I don't think inserting br tags are necessary at all. Let me know if there are any issues.