### PR TITLE
Add inline support for a range of useful text files

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -19,6 +19,7 @@ var MEDIASOURCE_VIDEO_EXTS = [ '.mp4', '.m4v', '.webm' ]
 var MEDIASOURCE_AUDIO_EXTS = [ '.mp3' ]
 var AUDIO_EXTS = [ '.wav', '.m4a', '.aac', '.ogg', '.oga' ]
 var IMAGE_EXTS = [ '.jpg', '.png', '.gif', '.bmp' ]
+var TEXT_EXTS = [ '.css', '.html', '.js', '.md', '.pdf', '.txt' ]
 
 global.WEBTORRENT_ANNOUNCE = [ TRACKER_URL ]
 
@@ -183,7 +184,7 @@ function onTorrent (torrent) {
         img.src = url
         img.alt = file.name
         util.log(img)
-      } else if (extname === '.pdf') {
+      } else if (TEXT_EXTS.indexOf(extname) >= 0) {
         var iframe = document.createElement('iframe')
         iframe.src = url
         util.log(iframe)


### PR DESCRIPTION
I added support for rendering the content of text files ... but I didn't stop at .txt files. This should be useful for web developers who want to share html, css, javascript, and markdown files!