### PR TITLE
Fix updateSpeed interval

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -166,10 +166,8 @@ function onTorrent (torrent) {
     )
   }
 
-  torrent.swarm.on('download', updateSpeed)
-  torrent.swarm.on('upload', updateSpeed)
-  setInterval(updateSpeed, 5000)
   updateSpeed()
+  setInterval(updateSpeed, 500)
 
   torrent.files.forEach(function (file) {
     // append file


### PR DESCRIPTION
Before the upload and download speed would update every time torrent.swarm.on was called. Now it updates every 500 milliseconds, which means it does not flicker and distract the user.