### PR TITLE
added required attribute to torrent magnet input

### DIFF
--- a/server/views/index.jade
+++ b/server/views/index.jade
@@ -17,7 +17,7 @@ block body
     h2 Start downloading
     form
       label(for='torrentId') Download from a magnet link or info hash
-      input(name='torrentId', placeholder='magnet:')
+      input(name='torrentId', placeholder='magnet:' required)
       button(type='submit') Download
 
     footer


### PR DESCRIPTION
added required attribute to torrent magnet input to prevent allowing the Download button being pressed and the "Downloading torrent from" text showing up without a torrent being entered.

![Screenshot](http://i.imgur.com/DR5V3jj.png)